### PR TITLE
Add ApiResponse wrapper and exception middleware

### DIFF
--- a/AuthenticationApp.Tests/AuthenticationApp.Tests.csproj
+++ b/AuthenticationApp.Tests/AuthenticationApp.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/AuthenticationApp.Tests/Middleware/ApiResponseSerializationTests.cs
+++ b/AuthenticationApp.Tests/Middleware/ApiResponseSerializationTests.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using AuthenticationApp.Domain.Response;
+using Xunit;
+
+namespace AuthenticationApp.Tests.Middleware
+{
+    public class ApiResponseSerializationTests
+    {
+        [Fact]
+        public void Serialize_SuccessResponse_ShouldContainSuccessTrue()
+        {
+            var response = ApiResponse<string>.CreateSuccess("data", "ok");
+            var json = JsonSerializer.Serialize(response);
+            Assert.Contains("\"Success\":true", json);
+            Assert.Contains("\"Data\":\"data\"", json);
+        }
+
+        [Fact]
+        public void Serialize_ErrorResponse_ShouldContainErrors()
+        {
+            var response = ApiResponse<object>.CreateFailure("fail", new[] { "err" });
+            var json = JsonSerializer.Serialize(response);
+            Assert.Contains("\"Success\":false", json);
+            Assert.Contains("err", json);
+        }
+    }
+}

--- a/AuthenticationApp.Tests/Middleware/ExceptionHandlingMiddlewareTests.cs
+++ b/AuthenticationApp.Tests/Middleware/ExceptionHandlingMiddlewareTests.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using AuthenticationApp.Domain.Exceptions;
+using AuthenticationApp.Domain.Response;
+using AuthenticationApp.Middleware;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace AuthenticationApp.Tests.Middleware
+{
+    public class ExceptionHandlingMiddlewareTests
+    {
+        [Fact]
+        public async Task UnhandledException_ShouldReturnInternalServerError()
+        {
+            using var host = await new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder.UseTestServer();
+                    webBuilder.Configure(app =>
+                    {
+                        app.UseMiddleware<ExceptionHandlingMiddleware>();
+                        app.Run(_ => throw new Exception("boom"));
+                    });
+                })
+                .StartAsync();
+
+            var client = host.GetTestClient();
+            var response = await client.GetAsync("/");
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            var api = JsonSerializer.Deserialize<ApiResponse<object>>(content);
+            Assert.False(api!.Success);
+            Assert.Contains("boom", api.Errors!.First());
+        }
+
+        [Fact]
+        public async Task ValidationException_ShouldReturnBadRequest()
+        {
+            using var host = await new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder.UseTestServer();
+                    webBuilder.Configure(app =>
+                    {
+                        app.UseMiddleware<ExceptionHandlingMiddleware>();
+                        app.Run(_ => throw new ValidationException(new[] { "field" }, "invalid"));
+                    });
+                })
+                .StartAsync();
+
+            var client = host.GetTestClient();
+            var response = await client.GetAsync("/");
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var api = JsonSerializer.Deserialize<ApiResponse<object>>(content);
+            Assert.False(api!.Success);
+            Assert.Contains("field", api.Errors!.First());
+        }
+    }
+}

--- a/AuthenticationApp/Domain/Exceptions/NotFoundException.cs
+++ b/AuthenticationApp/Domain/Exceptions/NotFoundException.cs
@@ -1,0 +1,7 @@
+namespace AuthenticationApp.Domain.Exceptions
+{
+    public class NotFoundException : Exception
+    {
+        public NotFoundException(string message) : base(message) { }
+    }
+}

--- a/AuthenticationApp/Domain/Exceptions/ValidationException.cs
+++ b/AuthenticationApp/Domain/Exceptions/ValidationException.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace AuthenticationApp.Domain.Exceptions
+{
+    public class ValidationException : Exception
+    {
+        public IEnumerable<string> ValidationErrors { get; }
+
+        public ValidationException(IEnumerable<string> errors, string message = "Validation failed") : base(message)
+        {
+            ValidationErrors = errors;
+        }
+    }
+}

--- a/AuthenticationApp/Domain/Response/ApiResponse.cs
+++ b/AuthenticationApp/Domain/Response/ApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace AuthenticationApp.Domain.Response
+{
+    public class ApiResponse<T>
+    {
+        public bool Success { get; set; }
+        public T? Data { get; set; }
+        public string? Message { get; set; }
+        public IEnumerable<string>? Errors { get; set; }
+
+        public static ApiResponse<T> CreateSuccess(T data, string? message = null)
+            => new ApiResponse<T> { Success = true, Data = data, Message = message };
+
+        public static ApiResponse<T> CreateFailure(string message, IEnumerable<string>? errors = null)
+            => new ApiResponse<T> { Success = false, Message = message, Errors = errors };
+    }
+}

--- a/AuthenticationApp/Endpoints/WeatherForecastEndpoints.cs
+++ b/AuthenticationApp/Endpoints/WeatherForecastEndpoints.cs
@@ -1,4 +1,6 @@
-﻿namespace AuthenticationApp.Endpoints
+using AuthenticationApp.Domain.Response;
+
+namespace AuthenticationApp.Endpoints
 {
     public static class WeatherForecastEndpoints
     {
@@ -19,7 +21,7 @@
                         summaries[Random.Shared.Next(summaries.Length)]
                     ))
                     .ToArray();
-                return forecast;
+                return Results.Ok(ApiResponse<WeatherForecast[]>.CreateSuccess(forecast));
             })
             .WithName("GetWeatherForecast")
             .RequireAuthorization()

--- a/AuthenticationApp/Middleware/ExceptionHandlingMiddleware.cs
+++ b/AuthenticationApp/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using AuthenticationApp.Domain.Exceptions;
+using AuthenticationApp.Domain.Response;
+
+namespace AuthenticationApp.Middleware
+{
+    public class ExceptionHandlingMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<ExceptionHandlingMiddleware> _logger;
+
+        public ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (Exception ex)
+            {
+                await HandleExceptionAsync(context, ex);
+            }
+        }
+
+        private Task HandleExceptionAsync(HttpContext context, Exception exception)
+        {
+            context.Response.ContentType = "application/json";
+            ApiResponse<object> apiResponse;
+            switch (exception)
+            {
+                case NotFoundException:
+                    context.Response.StatusCode = StatusCodes.Status404NotFound;
+                    apiResponse = ApiResponse<object>.CreateFailure(exception.Message);
+                    break;
+                case ValidationException ve:
+                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    apiResponse = ApiResponse<object>.CreateFailure(exception.Message, ve.ValidationErrors);
+                    break;
+                default:
+                    context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                    apiResponse = ApiResponse<object>.CreateFailure("Ocorreu um erro inesperado.", new[] { exception.Message });
+                    break;
+            }
+
+            var json = JsonSerializer.Serialize(apiResponse);
+            return context.Response.WriteAsync(json);
+        }
+    }
+}

--- a/AuthenticationApp/Program.cs
+++ b/AuthenticationApp/Program.cs
@@ -126,6 +126,8 @@ builder.Services.AddAuthorization();
 
 var app = builder.Build();
 
+app.UseMiddleware<AuthenticationApp.Middleware.ExceptionHandlingMiddleware>();
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
## Summary
- add ApiResponse<T> model
- implement custom NotFoundException and ValidationException classes
- add ExceptionHandlingMiddleware and register in Program
- refactor endpoints to return ApiResponse
- add serialization and middleware tests
- include TestHost package for new tests

## Testing
- `dotnet build AuthenticationApp/AuthenticationApp.csproj -nologo`
- `dotnet build AuthenticationApp.Tests/AuthenticationApp.Tests.csproj -nologo`
- `dotnet test AuthenticationApp.Tests/AuthenticationApp.Tests.csproj -nologo --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6848dfc821d0833390aa29b81f26cd82