### PR TITLE
Update README getting started instructions

### DIFF
--- a/AuthenticationApp.AzureFunc.EmailLogin/readme.md
+++ b/AuthenticationApp.AzureFunc.EmailLogin/readme.md
@@ -60,6 +60,7 @@ The function will send an email to `user@example.com` about the login event.
 1. Set up your `secrets.json` with the RabbitMQ connection string.
 2. Add your MailTrap (or SMTP) credentials to User Secrets or environment variables.
 3. Run the function app using Visual Studio or the .NET CLI.
+4. To use Docker, build the image with `docker build -t authenticationapp-emailfunc .` and run it or start everything with the main project's `docker-compose.yml`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ AuthenticationApp is a .NET 8-based application designed to provide user authent
 - Secure password storage using BCrypt.
 - OpenAPI/Scalar integration for API documentation.
 - Modular and testable architecture.
+- Change password functionality.
+- Request validation with **FluentValidation**.
+- Centralized API responses and global exception handling.
+- Redis-based refresh token cache with mass logout capability.
+- RabbitMQ integration for asynchronous events.
+- Email notifications via Azure Functions.
+- Dockerized environment with `docker-compose`.
 
 ## Libraries Used
 The solution uses the following libraries:
@@ -20,6 +27,9 @@ The solution uses the following libraries:
 - **[MongoDB.Driver](https://www.nuget.org/packages/MongoDB.Driver)** (v3.3.0): For MongoDB database access.
 - **[Scalar.AspNetCore](https://www.nuget.org/packages/Scalar.AspNetCore)** (v2.1.13): For API reference generation.
 - **[Swashbuckle.AspNetCore](https://www.nuget.org/packages/Swashbuckle.AspNetCore)** (v6.6.2): For Swagger UI and API documentation.
+- **[FluentValidation.AspNetCore](https://www.nuget.org/packages/FluentValidation.AspNetCore)** (v11.3.0): For request validation.
+- **[RabbitMQ.Client](https://www.nuget.org/packages/RabbitMQ.Client)** (v6.8.1): For message queue integration.
+- **[StackExchange.Redis](https://www.nuget.org/packages/StackExchange.Redis)** (v2.8.31) and **[Microsoft.Extensions.Caching.StackExchangeRedis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis)** (v10.0.0-preview.3.25172.1): For Redis caching.
 
 ### Test Project (`AuthenticationApp.Tests.csproj`)
 - **[coverlet.collector](https://www.nuget.org/packages/coverlet.collector)** (v6.0.0): For code coverage collection.
@@ -35,17 +45,22 @@ The solution uses the following libraries:
 - **Services**: Encapsulates business logic (e.g., `UserService` for user management).
 - **Endpoints**: Defines API routes (e.g., `UserEndpoints` and `AuthEndpoints`).
 - **Unit of Work**: Manages database transactions (`UnitOfWork`).
+- **Caching**: `RedisCacheService` stores refresh tokens and other cached data.
+- **Messaging**: `QueuePublisher` uses RabbitMQ to dispatch login events.
 
 ### Authentication and Authorization
 - **JWT Authentication**: Configured using `Microsoft.AspNetCore.Authentication.JwtBearer` to validate tokens.
 - **Refresh Tokens**: Implemented to allow users to renew their sessions securely.
 - **Password Hashing**: Uses BCrypt for secure password storage.
+- **Change Password**: Endpoint available to update user passwords.
+- **Request Validation**: Input models validated with FluentValidation.
 
 ### Database
 - **MongoDB**: The application uses MongoDB as its database, with `MongoDB.Driver` for data access. The `MongoDbContext` class manages the database connection.
 
 ### API Documentation
 - **Scalar/OpenAPI**: Integrated using `Swashbuckle.AspNetCore` and `Microsoft.AspNetCore.OpenApi` for interactive API documentation.
+- **ApiResponse Wrapper**: Standardizes responses and error handling.
 
 ### Testing
 - Unit tests are written using xUnit and Moq to ensure the reliability of services and repositories.
@@ -54,9 +69,10 @@ The solution uses the following libraries:
 
 ## Getting Started
 1. Clone the repository.
-2. Configure the `appsettings.json` file with your MongoDB connection string and JWT settings.
+2. Configure the `appsettings.json` file with your MongoDB connection string and JWT settings. Use `dotnet user-secrets` (the `secrets.json` file) to store the connection string and JWT private key locally.
 3. Build and run the solution using Visual Studio 2022 or the .NET CLI.
-4. Access the Swagger UI at `https://localhost:<port>/scalar`.
+4. Alternatively, create an `.env` file and execute `docker compose up` inside the `AuthenticationApp` folder to start the API, Redis, RabbitMQ and the Azure Function.
+5. Access the Scalar UI at `https://localhost:<port>/scalar`.
 
 ## License
 This project is licensed under the MIT License.


### PR DESCRIPTION
## Summary
- note using `dotnet user-secrets` to store the MongoDB connection string and JWT private key
- clarify that the API docs are accessed via the Scalar UI

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685725155084833390a321d2eccb5509